### PR TITLE
Aggiornata pipeline (job sbom CycloneDX), parent govpay-bom 1.1.3 e v…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -163,10 +163,56 @@ jobs:
         --lockfile
         ./pom.xml
 
+  # ── SBOM CycloneDX ───────────────────────────────────────────────────
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: >-
+      vars.DISABLE_SBOM_JOB != 'true' &&
+      (github.event_name == 'push' &&
+       (github.ref_name == 'main' || github.ref_type == 'tag' || vars.FORCE_SBOM_JOB == 'true'))
+    continue-on-error: ${{ vars.FORCE_SBOM_JOB == 'true' && github.ref_type != 'tag' && github.ref_name != 'main' }}
+    env:
+      SBOM_CYCLONEDX_PLUGIN_VERSION: '2.9.1'   # ← adegua al valore reale
+      SBOM_CYCLONEDX_SCHEMA_VERSION: '1.6'     # ← adegua al valore reale
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Generate SBOM (CycloneDX json + xml)
+        run: |
+          mkdir -p sbom/cyclonedx
+          echo "Generazione SBOM CycloneDX (json + xml) ..."
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${SBOM_CYCLONEDX_PLUGIN_VERSION}:makeAggregateBom \
+            -DoutputDirectory=sbom/cyclonedx \
+            -DoutputName=bom.cdx \
+            -DoutputFormat=all \
+            -DschemaVersion=${SBOM_CYCLONEDX_SCHEMA_VERSION} \
+            -DskipNotDeployed=false \
+            -DincludeTestScope=false
+          ls -la sbom/cyclonedx/
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-report
+          path: sbom/
+          retention-days: 30
+
   # ── GitHub Release (solo tag) ────────────────────────────────────────
   release:
     runs-on: ubuntu-latest
-    needs: [ build, osv-scan ]
+    needs: [ build, osv-scan, sbom ]
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -193,6 +239,12 @@ jobs:
         name: OSV Scanner SARIF file
         path: reports/osv/
 
+    - name: Download SBOM
+      uses: actions/download-artifact@v7
+      with:
+        name: sbom-report
+        path: reports/sbom/
+
     - name: Rename artifacts with tag version
       run: |
         cp jar/govpay-gde-api.war jar/govpay-gde-api-${{ github.ref_name }}.war
@@ -200,7 +252,7 @@ jobs:
 
     - name: Assemble reports ZIP
       run: |
-        mkdir -p reports/owasp reports/jacoco reports/osv
+        mkdir -p reports/owasp reports/jacoco reports/osv reports/sbom
 
         # OWASP e JaCoCo dall'artifact build
         cp jar/dependency-check-report.html reports/owasp/ 2>/dev/null || true
@@ -225,6 +277,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  # ── Docker build & push (solo tag, dopo release) ─────────────────────
   docker:
     runs-on: ubuntu-latest
     needs: release

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2026-05-05  Giuliano Pintori <pintori@link.it>
+
+	* [Build]
+	Aggiornato parent govpay-bom alla versione 1.1.3.
+	Avanzamento versione 1.1.2.
+
+	* [Pipeline]
+	Aggiunto job sbom per la generazione del SBOM CycloneDX (formato JSON e XML,
+	schema 1.6) tramite cyclonedx-maven-plugin 2.9.1. Il job e' attivabile/disattivabile
+	tramite le variabili DISABLE_SBOM_JOB e FORCE_SBOM_JOB ed e' eseguito su push
+	a main e su tag.
+	Il job release ora dipende anche da sbom e include il report SBOM nello ZIP
+	dei report allegato alla release GitHub.
+
 2026-04-23  Giuliano Pintori <pintori@link.it>
 
 	* [Pipeline]

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.gov4j.govpay</groupId>
 		<artifactId>govpay-bom</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>1.1.3</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>it.govpay.gde</groupId>
 	<artifactId>gde-api</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<packaging>${packaging.type}</packaging>
 	<name>GovPay - Giornale degli Eventi - API</name>
 	<description>GovPay Modulo per la registrazione degli eventi</description>


### PR DESCRIPTION
…ersione 1.1.2

Allineata la pipeline a govpay-fdr-batch: aggiunto job sbom per generazione SBOM CycloneDX (JSON+XML, schema 1.6) tramite cyclonedx-maven-plugin 2.9.1, gated da DISABLE_SBOM_JOB/FORCE_SBOM_JOB. Il job release ora dipende da sbom e include il report nello ZIP allegato alla release GitHub.
Aggiornato parent govpay-bom 1.1.3-SNAPSHOT -> 1.1.3 e avanzamento versione 1.1.2.