### PR TITLE
Issue #21 Ridotto a TRACE il payload completo dell'evento alla creazi…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+2026-05-11  Giuliano Pintori <pintori@link.it>
+
+	* [Logging]
+	Ridotto a TRACE il log del payload completo alla ricezione di un nuovo evento
+	(controller addEvento). A livello INFO viene ora loggata una riga sintetica con
+	i metadati essenziali dell'evento (componente, categoria, tipo/sottotipo, esito,
+	idDominio, iuv) per evitare di inquinare i log di produzione con payload
+	voluminosi.
+	Rivisti gli altri statement di log del controller:
+	- Salvataggio evento: chiusura promossa da DEBUG a INFO con id entita' creata.
+	- Ricerca eventi: start e chiusura demotati da INFO a DEBUG (alta frequenza);
+	  chiusura arricchita con il numero totale di eventi trovati.
+	OffsetDateTimeDeserializer: DateTimeParseException nel percorso di recovery
+	loggata a WARN (era ERROR) usando placeholder slf4j al posto della
+	concatenazione di stringhe.
+
 2026-05-05  Giuliano Pintori <pintori@link.it>
 
 	* [Build]

--- a/src/main/java/it/govpay/gde/controller/GdeController.java
+++ b/src/main/java/it/govpay/gde/controller/GdeController.java
@@ -53,13 +53,19 @@ public class GdeController implements EventiApi{
 
 	@Override
 	public ResponseEntity<Void> addEvento(@Valid NuovoEvento nuovoEvento) {
-		this.logger.info("Salvataggio evento: {}", nuovoEvento);
-		
+		this.logger.info("Salvataggio evento [componente={}, categoria={}, tipo={}/{}, esito={}, idDominio={}, iuv={}]",
+				nuovoEvento.getComponente(), nuovoEvento.getCategoriaEvento(),
+				nuovoEvento.getTipoEvento(), nuovoEvento.getSottotipoEvento(),
+				nuovoEvento.getEsito(), nuovoEvento.getIdDominio(), nuovoEvento.getIuv());
+		if (this.logger.isTraceEnabled()) {
+			this.logger.trace("Salvataggio evento - payload completo: {}", nuovoEvento);
+		}
+
 		EventoEntity entity = this.nuovoEventoMapperImpl.nuovoEventoToEventoEntity(nuovoEvento);
 		
 		entity = this.eventoRepository.save(entity);
-		
-		this.logger.debug("Salvataggio evento completato.");
+
+		this.logger.info("Salvataggio evento completato [id={}]", entity.getId());
 		
 		MultiValueMap<String, String> headers = new HttpHeaders();
 		
@@ -78,7 +84,7 @@ public class GdeController implements EventiApi{
 			EsitoEvento esito, RuoloEvento ruolo, String sottotipoEvento, String tipoEvento,
 			ComponenteEvento componente, Integer severitaDa, Integer severitaA) {
 		
-		this.logger.info("Ricerca eventi...");
+		this.logger.debug("Ricerca eventi...");
 		
 		Specification<EventoEntity> spec = creaFiltriDiRicercaDate(dataDa, dataA);
 		
@@ -101,7 +107,7 @@ public class GdeController implements EventiApi{
 			ret.addItemsItem(this.eventoMapperImpl.eventoEntityToEvento(user));
 		}
 		
-		this.logger.info("Ricerca eventi completata");
+		this.logger.debug("Ricerca eventi completata [trovati={}]", eventi.getTotalElements());
 		
 		return ResponseEntity.ok(ret);
 	}

--- a/src/main/java/it/govpay/gde/utils/OffsetDateTimeDeserializer.java
+++ b/src/main/java/it/govpay/gde/utils/OffsetDateTimeDeserializer.java
@@ -51,7 +51,7 @@ public class OffsetDateTimeDeserializer extends StdScalarDeserializer<OffsetDate
 			try {
 				return OffsetDateTime.parse(dateString, formatter);
 			}catch (DateTimeParseException e) {
-				logger.error("Error parsing date: " + e.getMessage(), e);
+				logger.warn("Parsing OffsetDateTime fallito, tentativo come LocalDateTime: {}", e.getMessage());
 				ZoneOffset offset = ZoneOffset.ofHoursMinutes(1, 0); // CET (Central European Time)
 				LocalDateTime localDateTime = LocalDateTime.parse(dateString, formatter);
 				if (localDateTime != null) {


### PR DESCRIPTION
…one e revisione log

Il controller addEvento ora logga a INFO solo i metadati essenziali dell'evento (componente, categoria, tipo/sottotipo, esito, idDominio, iuv); il payload completo viene loggato a TRACE, guardato da isTraceEnabled(), evitando rumore in produzione.

Revisione degli altri statement di log:
- Salvataggio evento: chiusura promossa da DEBUG a INFO con id entita' creata
- Ricerca eventi: start e chiusura demotati da INFO a DEBUG (alta frequenza); chiusura arricchita con il numero totale di eventi trovati
- OffsetDateTimeDeserializer: DateTimeParseException nel percorso di recovery loggata a WARN (era ERROR), placeholder slf4j al posto della concatenazione