### PR TITLE
CI: versioni SNAPSHOT su main e immagine Docker di sviluppo

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
     steps:
     - uses: actions/checkout@v6
       with:
@@ -76,6 +79,13 @@ jobs:
         VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=owasp.plugin.version)"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "OWASP Dependency-Check version: $VERSION"
+
+    - name: Read project version from pom.xml
+      id: version
+      run: |
+        VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Project version: $VERSION"
 
     - name: Cache OWASP Dependency-Check DB
       id: owasp-cache
@@ -220,6 +230,67 @@ jobs:
           retention-days: 30
 
   # ── GitHub Release (solo tag) ────────────────────────────────────────
+  # ── Immagine Docker di sviluppo (solo push su main, solo SNAPSHOT) ────
+  # Serve a eseguire i test di integrazione prima di un rilascio: pubblica su
+  # un repo separato (linkitaly/govpay-gde-api-dev) cosi' una SNAPSHOT non finisce mai
+  # nel repo delle immagini di produzione.
+  # Usa Dockerfile.daFile, che prende il jar dal build context: Dockerfile.github
+  # scarica il jar da una GitHub release, che per una SNAPSHOT non esiste.
+  docker-dev:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+    steps:
+    - name: Skip (not a SNAPSHOT)
+      if: ${{ !endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      run: echo "Versione ${{ needs.build.outputs.version }} non e' una SNAPSHOT -> nessuna immagine di sviluppo pubblicata."
+
+    - name: Checkout code
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      uses: actions/checkout@v6
+
+    - name: Download jar from build job
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      uses: actions/download-artifact@v7
+      with:
+        name: govpay-gde-api
+        path: artifacts/
+
+    - name: Set up Docker Buildx
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      uses: docker/setup-buildx-action@v4
+
+    - name: Login to Docker Hub
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Prepare build context
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      run: |
+        set -euo pipefail
+        cd docker
+        rm -rf buildcontext
+        mkdir -p buildcontext/
+        cp -fr commons buildcontext/
+        cp -f ../artifacts/govpay-gde-api.jar buildcontext/
+        ls -lh buildcontext/
+
+    - name: Build and push development image
+      if: ${{ endsWith(needs.build.outputs.version, '-SNAPSHOT') }}
+      uses: docker/build-push-action@v6
+      with:
+        context: docker/buildcontext
+        file: docker/govpay-gde/Dockerfile.daFile
+        push: true
+        build-args: |
+          govpay_gde_fullversion=${{ needs.build.outputs.version }}
+        tags: |
+          linkitaly/govpay-gde-api-dev:${{ needs.build.outputs.version }}
+
   release:
     runs-on: ubuntu-latest
     needs: [ build, osv-scan, sbom ]
@@ -228,6 +299,36 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+
+    # Con il versionamento SNAPSHOT su main, un tag applicato senza aver prima
+    # tolto -SNAPSHOT dal pom produrrebbe una release costruita da uno SNAPSHOT.
+    # Il tag deve inoltre coincidere con la versione del pom, perche' gli asset
+    # della release e il download in Dockerfile.github sono nominati sul tag.
+    - name: Verify tag matches a non-SNAPSHOT pom version
+      run: |
+        set -euo pipefail
+        VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+        TAG="${{ github.ref_name }}"
+        echo "pom version: $VERSION"
+        echo "tag        : $TAG"
+        case "$VERSION" in
+          *-SNAPSHOT)
+            echo "::error::Il pom e' alla versione $VERSION. Togliere -SNAPSHOT e ricreare il tag prima di rilasciare."
+            exit 1
+            ;;
+        esac
+        if [ "$VERSION" != "$TAG" ]; then
+          echo "::error::Il tag ($TAG) non coincide con la versione del pom ($VERSION). Gli asset della release e il download in Dockerfile.github sono nominati sul tag."
+          exit 1
+        fi
+        echo "Versione e tag coincidono, procedo."
 
     # Artifact build (JAR, WAR, report OWASP e JaCoCo)
     - name: Download govpay-gde-api artifact

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>it.govpay.gde</groupId>
 	<artifactId>gde-api</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>${packaging.type}</packaging>
 	<name>GovPay - Giornale degli Eventi - API</name>
 	<description>GovPay Modulo per la registrazione degli eventi</description>


### PR DESCRIPTION
Allinea la pipeline a **[govpay-console-api#64](https://github.com/link-it/govpay-console-api/pull/64)**: versionamento SNAPSHOT e immagine Docker di sviluppo, per eseguire i **test di integrazione prima di un rilascio**.

## Cosa non è stato portato, e perché

Le altre tre correzioni fatte su `console-api` ([#61](https://github.com/link-it/govpay-console-api/pull/61)) **non si applicano**: questo repo era già a posto, era `console-api` a essere rimasto indietro.

- **Path del Dockerfile** nel job `docker`: già corretto, il file referenziato esiste.
- **Nome del build-arg**: già allineato all'`ARG` del Dockerfile.
- **Chiave della cache OWASP**: già identica a quella di `refresh-owasp-db.yml` (`${os}-owasp-v${versione}-${data}`), step di lettura della versione del plugin incluso.

## Versionamento

`pom.xml`: **`2.0.0` → `2.0.1-SNAPSHOT`**. La `2.0.0` è **già rilasciata** (tag esistente), quindi `main` passa alla SNAPSHOT successiva.

Il flusso è quello già in uso in `govpay-common`: `main` porta la SNAPSHOT, prima del tag si toglie `-SNAPSHOT` dal pom, si tagga, poi si bumpa `main` alla SNAPSHOT successiva.

Effetto collaterale utile: `main` era fermo su una versione **già rilasciata**, quindi un tag creato oggi avrebbe **ri-pubblicato la `2.0.0`**. Il passaggio a SNAPSHOT chiude anche quello. Da notare che la guardia sul rilascio da sola non l'avrebbe intercettato: `2.0.0` non è una SNAPSHOT e coinciderebbe col tag.

## Immagine di sviluppo — nuovo job `docker-dev`

Pubblica su **`linkitaly/govpay-gde-api-dev`** con il tag della versione (`2.0.1-SNAPSHOT`), su push su `main` e solo se la versione è una SNAPSHOT. Repo separato da quello di produzione: una SNAPSHOT non finisce mai fra le immagini rilasciate. **Il repo esiste già** su Docker Hub, la precondizione è soddisfatta.

Tre scelte da segnalare in review:

- **Usa `Dockerfile.daFile`, non `Dockerfile.github`.** Il secondo scarica il jar da una GitHub release, che per una SNAPSHOT non esiste. Il primo lo prende dal build context, ed è la stessa variante che `build_image.sh` seleziona con l'opzione `-l`.
- **Il jar arriva dall'artifact del job `build`**, non da una ricompilazione.
- **`needs: build` e non `[build, osv-scan, sbom]`** come fa `release`, per tenere corto il ciclo di feedback. Su `main` `osv-scan` ha `fail-on-vuln` attivo, quindi un problema di sicurezza rende comunque rosso il run.

La versione è letta **una volta sola** nel job `build` ed esposta come output, così `docker-dev` non ha bisogno né di Maven né del JDK.

## Guardia sul rilascio

Con `main` sempre a `-SNAPSHOT` nasce un modo di sbagliare che prima non esisteva: un tag applicato senza aver prima corretto il pom produrrebbe una release costruita da uno SNAPSHOT. Oggi `release` gira su qualsiasi tag senza controllare nulla.

Il job verifica ora che la versione del pom **non sia una SNAPSHOT** e che **coincida con il tag**. Il secondo controllo non è pedanteria: gli asset della release e il download in `Dockerfile.github` sono nominati sul tag, quindi una divergenza romperebbe anche la costruzione dell'immagine di produzione.

## Verifica

- YAML validato; `outputs` del job `build` e `needs` di `docker-dev` controllati.
- Coerenza verificata sul filesystem: `Dockerfile.daFile` presente, build-arg ↔ `ARG` coincidenti, nome del jar copiato ↔ `finalName` coincidenti.
- **`docker-dev` non è verificabile prima del merge**: gira solo su push su `main`, non su `pull_request`. Il primo run dopo il merge è la prova. Su `console-api` è passato al primo colpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
